### PR TITLE
Add support for video links in ColumnsPlus block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ logs/*
 node_modules/*
 
 helix-importer-ui
+.idea

--- a/blocks/columnsplus/columnsplus.css
+++ b/blocks/columnsplus/columnsplus.css
@@ -25,7 +25,7 @@ main .section.columnsplus-container {
   padding: 32px 0;
 }
 
-.columnsplus img {
+.columnsplus :is(img, video) {
   width: 100%;
   opacity: 0;
   position: relative;
@@ -33,11 +33,11 @@ main .section.columnsplus-container {
   transition: transform 0.5s ease-out, opacity 1s;
 }
 
-.columnsplus .columnsplus-left img {
+.columnsplus .columnsplus-left :is(img, video) {
   transform: translate(-50px, 0);
 }
 
-.columnsplus img.enter {
+.columnsplus :is(img, video).enter {
   opacity: 1;
   transform: translate(0, 0);
 }

--- a/blocks/columnsplus/columnsplus.js
+++ b/blocks/columnsplus/columnsplus.js
@@ -31,6 +31,23 @@ function setClassForBrightness(image, canvas, wrapper) {
   }
 }
 
+function decorateVideo(videoLink) {
+  const videoWrapper = videoLink.closest('div');
+  if (videoWrapper && videoWrapper.children.length === 1) {
+    const videoElement = document.createElement('video');
+    const sourceElement = document.createElement('source');
+    sourceElement.src = videoLink.href;
+    sourceElement.type = 'video/mp4';
+    videoElement.appendChild(sourceElement);
+    videoElement.autoplay = true;
+    videoElement.loop = true;
+    videoElement.playsInline = true;
+    videoElement.muted = true;
+    videoLink.replaceWith(videoElement);
+    videoWrapper.classList.add('columnsplus-img-col');
+  }
+}
+
 export default function decorate(block) {
   const cols = [...block.firstElementChild.nextElementSibling.children];
   block.classList.add(`columnsplus-${cols.length}-cols`);
@@ -61,6 +78,10 @@ export default function decorate(block) {
             picWrapper.classList.add('columnsplus-img-col');
           }
         }
+      }
+      const link = col.querySelector('a');
+      if (link && link.href.endsWith('.mp4')) {
+        decorateVideo(link);
       }
     });
   });
@@ -99,7 +120,7 @@ export default function decorate(block) {
     if (ch.length > 1 && lastbgwrapper != null) lastbgwrapper.appendChild(row);
   });
 
-  block.querySelectorAll('img').forEach((img) => {
-    observer.observe(img);
+  block.querySelectorAll('img, video').forEach((media) => {
+    observer.observe(media);
   });
 }

--- a/test/blocks/columnsplus/block.html
+++ b/test/blocks/columnsplus/block.html
@@ -1,0 +1,81 @@
+<div class="columnsplus">
+  <div>
+    <div>
+      <picture>
+        <source type="image/webp" srcset="./media_17be0b7bf7d3decb124f81bd7318054aca3707a3f.png?width=2000&amp;format=webply&amp;optimize=medium" media="(min-width: 600px)">
+        <source type="image/webp" srcset="./media_17be0b7bf7d3decb124f81bd7318054aca3707a3f.png?width=750&amp;format=webply&amp;optimize=medium">
+        <source type="image/png" srcset="./media_17be0b7bf7d3decb124f81bd7318054aca3707a3f.png?width=2000&amp;format=png&amp;optimize=medium" media="(min-width: 600px)">
+        <img loading="lazy" alt="" type="image/png" src="./media_17be0b7bf7d3decb124f81bd7318054aca3707a3f.png?width=750&amp;format=png&amp;optimize=medium" width="1037" height="691">
+      </picture>
+    </div>
+  </div>
+  <div>
+    <div>
+      <h2 id="who-we-are">Who we are</h2>
+      <p>"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."</p>
+    </div>
+    <div>
+      <picture>
+        <source type="image/webp" srcset="./media_163948a3164e18193abac53d61d6b2ac4a053cc17.jpeg?width=2000&amp;format=webply&amp;optimize=medium" media="(min-width: 600px)">
+        <source type="image/webp" srcset="./media_163948a3164e18193abac53d61d6b2ac4a053cc17.jpeg?width=750&amp;format=webply&amp;optimize=medium">
+        <source type="image/jpeg" srcset="./media_163948a3164e18193abac53d61d6b2ac4a053cc17.jpeg?width=2000&amp;format=jpeg&amp;optimize=medium" media="(min-width: 600px)">
+        <img loading="lazy" alt="" type="image/jpeg" src="./media_163948a3164e18193abac53d61d6b2ac4a053cc17.jpeg?width=750&amp;format=jpeg&amp;optimize=medium" width="1600" height="1066">
+      </picture>
+    </div>
+  </div>
+  <div>
+    <div>
+      <picture>
+        <source type="image/webp" srcset="./media_1adfb9683e6dc87878203dfa95583bc6f907bb716.jpeg?width=2000&amp;format=webply&amp;optimize=medium" media="(min-width: 600px)">
+        <source type="image/webp" srcset="./media_1adfb9683e6dc87878203dfa95583bc6f907bb716.jpeg?width=750&amp;format=webply&amp;optimize=medium">
+        <source type="image/jpeg" srcset="./media_1adfb9683e6dc87878203dfa95583bc6f907bb716.jpeg?width=2000&amp;format=jpeg&amp;optimize=medium" media="(min-width: 600px)">
+        <img loading="lazy" alt="" type="image/jpeg" src="./media_1adfb9683e6dc87878203dfa95583bc6f907bb716.jpeg?width=750&amp;format=jpeg&amp;optimize=medium" width="1600" height="1066">
+      </picture>
+    </div>
+  </div>
+  <div>
+    <div>
+      <picture>
+        <source type="image/webp" srcset="./media_197ee2b378315ddd0e1920243eac568a433bc8293.jpeg?width=2000&amp;format=webply&amp;optimize=medium" media="(min-width: 600px)">
+        <source type="image/webp" srcset="./media_197ee2b378315ddd0e1920243eac568a433bc8293.jpeg?width=750&amp;format=webply&amp;optimize=medium">
+        <source type="image/jpeg" srcset="./media_197ee2b378315ddd0e1920243eac568a433bc8293.jpeg?width=2000&amp;format=jpeg&amp;optimize=medium" media="(min-width: 600px)">
+        <img loading="lazy" alt="" type="image/jpeg" src="./media_197ee2b378315ddd0e1920243eac568a433bc8293.jpeg?width=750&amp;format=jpeg&amp;optimize=medium" width="1600" height="960">
+      </picture>
+    </div>
+    <div>
+      <h2 id="what-we-do">What we do</h2>
+      <p>"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."</p>
+    </div>
+  </div>
+  <div>
+    <div>
+      <h2 id="our-work">Our work</h2>
+      <p>"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."</p>
+    </div>
+    <div>
+      <picture>
+        <source type="image/webp" srcset="./media_163948a3164e18193abac53d61d6b2ac4a053cc17.jpeg?width=2000&amp;format=webply&amp;optimize=medium" media="(min-width: 600px)">
+        <source type="image/webp" srcset="./media_163948a3164e18193abac53d61d6b2ac4a053cc17.jpeg?width=750&amp;format=webply&amp;optimize=medium">
+        <source type="image/jpeg" srcset="./media_163948a3164e18193abac53d61d6b2ac4a053cc17.jpeg?width=2000&amp;format=jpeg&amp;optimize=medium" media="(min-width: 600px)">
+        <img loading="lazy" alt="" type="image/jpeg" src="./media_163948a3164e18193abac53d61d6b2ac4a053cc17.jpeg?width=750&amp;format=jpeg&amp;optimize=medium" width="1600" height="1066">
+      </picture>
+    </div>
+  </div>
+  <div>
+    <div>
+      <picture>
+        <source type="image/webp" srcset="./media_1add1dbadf90dea5bddde840bb115c66ae23aa4da.jpeg?width=2000&amp;format=webply&amp;optimize=medium" media="(min-width: 600px)">
+        <source type="image/webp" srcset="./media_1add1dbadf90dea5bddde840bb115c66ae23aa4da.jpeg?width=750&amp;format=webply&amp;optimize=medium">
+        <source type="image/jpeg" srcset="./media_1add1dbadf90dea5bddde840bb115c66ae23aa4da.jpeg?width=2000&amp;format=jpeg&amp;optimize=medium" media="(min-width: 600px)">
+        <img loading="lazy" alt="" type="image/jpeg" src="./media_1add1dbadf90dea5bddde840bb115c66ae23aa4da.jpeg?width=750&amp;format=jpeg&amp;optimize=medium" width="1042" height="423">
+      </picture>
+    </div>
+  </div>
+  <div>
+    <div>
+      <h2 id="our-philosophy">Our philosophy</h2>
+      <p>"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."</p>
+    </div>
+    <div><a href="./media_10e3adbdc11b9eb6fa90c626414146f99f000a68f.mp4">https://main--aem-cloud-foundation-site--adobe.hlx.page/media_10e3adbdc11b9eb6fa90c626414146f99f000a68f.mp4</a></div>
+  </div>
+</div>

--- a/test/blocks/columnsplus/columnsplus.test.js
+++ b/test/blocks/columnsplus/columnsplus.test.js
@@ -1,0 +1,37 @@
+/* eslint-disable no-unused-expressions */
+/* global describe it */
+
+import { readFile } from '@web/test-runner-commands';
+import { expect } from '@esm-bundle/chai';
+
+const sleep = async (time = 1000) => new Promise((resolve) => {
+  setTimeout(() => {
+    resolve(true);
+  }, time);
+});
+
+describe('ColumnsPlus block', () => {
+  // eslint-disable-next-line no-undef
+  before(async () => {
+    const { decorateBlock, loadBlock } = await import('../../../scripts/lib-franklin.js');
+    document.body.innerHTML = await readFile({ path: './block.html' });
+    const columnPlusBlock = document.querySelector('div.columnsplus');
+    await decorateBlock(columnPlusBlock);
+    await loadBlock(columnPlusBlock);
+    await sleep();
+  });
+
+  it('Replace mp4 link with a video element', async () => {
+    const video = document.querySelector('video');
+    expect(video).to.exist;
+    expect(video.loop).to.be.true;
+    expect(video.autoplay).to.be.true;
+    expect(video.muted).to.be.true;
+    expect(video.playsInline).to.be.true;
+
+    const source = video.firstElementChild;
+    expect(source).to.exist;
+    expect(source.src).to.equal('http://localhost:2000/media_10e3adbdc11b9eb6fa90c626414146f99f000a68f.mp4');
+    expect(source.type).to.equal('video/mp4');
+  });
+});


### PR DESCRIPTION
A link to a mp4 file is converted to a video element.

Test URLs:
- Before: https://main--aem-cloud-foundation-site--adobe.hlx.page/drafts/jelmini/
- After: https://video_support--aem-cloud-foundation-site--adobe.hlx.page/drafts/jelmini/
