### PR TITLE
Add fade-in transition to menu (js + css)

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -263,6 +263,11 @@ header nav .nav-sections ul > li > ul > li:hover {
   header nav .nav-sections > ul > li > ul {
     display: none;
     position: relative;
+    transition: opacity 0.2s linear;
+  }
+
+  header nav .nav-sections > ul > li > ul.hidden {
+    opacity: 0;
   }
 
   header nav .nav-sections > ul > li[aria-expanded="true"] > ul {

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -43,6 +43,10 @@ function focusNavSection() {
 function toggleAllNavSections(sections, expanded = false) {
   sections.querySelectorAll('.nav-sections > ul > li').forEach((section) => {
     section.setAttribute('aria-expanded', expanded);
+    const menu = section.querySelector('ul');
+    if (menu) {
+      menu.classList.add('hidden');
+    }
   });
 }
 
@@ -96,6 +100,20 @@ function toggleMenu(nav, navSections, forceExpanded = null) {
   }
 }
 
+function menuFadeIn(section, expand) {
+  const menu = section.querySelector('ul');
+  section.setAttribute('aria-expanded', expand);
+  if (expand) {
+    // Switching from 'display node' to 'display: block' breaks the transition animations.
+    // Waiting some time before removing the 'hidden' class allows the fade-in animation to run.
+    setTimeout(() => {
+      menu.classList.remove('hidden');
+    }, 20);
+  } else {
+    menu.classList.add('hidden');
+  }
+}
+
 /**
  * decorates the header, mainly the nav
  * @param {Element} block The header block element
@@ -129,7 +147,7 @@ export default async function decorate(block) {
           if (isDesktop.matches) {
             const expanded = navSection.getAttribute('aria-expanded') === 'true';
             toggleAllNavSections(navSections);
-            navSection.setAttribute('aria-expanded', expanded ? 'false' : 'true');
+            menuFadeIn(navSection, !expanded);
           }
         });
       });


### PR DESCRIPTION
Pro: can use 'display: none' to properly hide elements from the DOM.
Con: as switching from 'display: none' to 'display: block' prevent CSS transitions to run, some javascript is needed to workaround this issue, by starting the transition with a small delay.

Test URLs:
- Before: https://main--aem-cloud-foundation-site--adobe.hlx.page/
- After: https://fade-menu-js-css--aem-cloud-foundation-site--adobe.hlx.page/